### PR TITLE
Updated copycat links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1269,8 +1269,8 @@ page will reorder these based on github stars and last repo update.
   <td>2014-12-08</td>
 </tr>
 <tr>
-  <td><a href="https://github.com/kuujo/copycat">copycat</a></td>
-  <td><a href="https://twitter.com/J_Halterman">Jordan Halterman</a></td>
+  <td><a href="https://github.com/atomix/copycat">copycat</a></td>
+  <td><a href="https://twitter.com/definekuujo">Jordan Halterman</a></td>
   <td>Java</td>
   <td>Apache2</td>
   <td>Yes</td>


### PR DESCRIPTION
Copycat recently moved to the atomix org. Updating the link:

https://github.com/atomix/copycat