### PR TITLE
change HydraBase quote to not mention master/slave terminology

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,10 +157,10 @@ warehouses. &hellip;
 </p>
 
 <p>
-HBase in a master-slave setup &hellip; requires failover to
+HBase in a &hellip; [primary-replica] setup &hellip; requires failover to
 be carried out at the cluster level, causes <strong>outages
-on the order of minutes of downtime when failing over from
-master to slave</strong>, and potentially results in data
+on the order of minutes of downtime when failing over
+&hellip;</strong>, and potentially results in data
 loss due to the asynchronous nature of the replication.
 &hellip;
 </p>
@@ -169,7 +169,7 @@ loss due to the asynchronous nature of the replication.
 Over the last year, <strong>we've been working on
 HydraBase</strong>, which avoids these limitations and
 <strong>provides higher reliability</strong> with the same
-storage footprint as a master-slave replicated setup.
+storage footprint as a &hellip; replicated setup.
 &hellip;
 </p>
 


### PR DESCRIPTION
This particular Facebook quote is featured prominently on the Homepage, and often is the first thing people see when browsing to raft.github.io. I don't feel particularly good about the fact that it uses the master/slave terminology, which is seen by many as inappropriate. While Facebook have not responded yet whether they would like to change the quoted blog post to make for a better quote, this works around the issue by omitting and annotating.

In order to promote inclusiveness, and actively work against discrimination in tech, several projects have started to evaluate the usage of the terms master/slave to replace them with primary/replica or leader/follower, since master/slave has negative connotations. Projects include:

- Drupal: https://www.drupal.org/node/2275877
- Django: https://github.com/django/django/pull/2692

Extensive discussion has happened in both cases, which I hope reduces the amount of discussion to get this change landed.

This is a change that is also happening outside of tech:

- https://www.washingtonpost.com/news/morning-mix/wp/2015/12/02/harvard-college-house-masters-to-get-new-titles-because-of-slavery-connotation/
- http://www.nhregister.com/article/NH/20151202/NEWS/151209895
- http://bigstory.ap.org/article/e27dc124377c41a1a81a83290c3c3f6e/penn-changes-name-dorm-masters-over-racial-concerns

For background, quoting from Wikipedia "Master/slave_(technology)":

Appropriateness of usage

In 2003, the County of Los Angeles in California asked that manufacturers, suppliers and contractors to stop using "master" and "slave" terminology on its products. The controversial decision is taken by the county "based on the cultural diversity and sensitivity of Los Angeles County". Following outcries about the decision, the County of Los Angeles issued a statement saying that the decision was "nothing more than a request". Due to the controversy, the term was selected as the most politically incorrect word in 2004 by Global Language Monitor.

In May 2014, github user fcurella submitted a pull request to the github repository for the Python framework django, initially changing it to leader/follower and finally to primary/replica. This triggered an active discussion of the appropriateness of the master/slave terminology as well as the appropriateness of the change.

In June 2014, Drupal 8 did the same as django did, citing that the word "replica" is already in use by IBM, Microsoft, Engine Yard, Amazon Web Services, and ACM.