### PR TITLE
Remove djui/eraft project since its discontinued

### DIFF
--- a/index.html
+++ b/index.html
@@ -914,16 +914,6 @@ page will reorder these based on github stars and last repo update.
   <td>2015-05-31</td>
 </tr>
 <tr>
-  <td><a href="https://github.com/djui/eraft">eraft</a></td>
-  <td><a href="https://twitter.com/uwe_">Uwe Dauernheim</a></td>
-  <td>Erlang</td>
-  <td></td>
-  <td></td>
-  <td></td>
-  <td></td>
-  <td>2013-05-18</td>
-</tr>
-<tr>
   <td><a href="https://github.com/cannedprimates/huckleberry">huckleberry</a></td>
   <td><a href="https://twitter.com/cannedprimates">Jakob Sievers</a></td>
   <td>Erlang</td>


### PR DESCRIPTION
The project page says: "Please use ZRaft Lib; the implementation below is incomplete and discontinued."