### PR TITLE
rename jraft to easyRaft due to duplication

### DIFF
--- a/index.html
+++ b/index.html
@@ -1830,7 +1830,7 @@ page will reorder these based on github stars and last repo update.
   <td>2019-07-21</td>
 </tr>
 <tr>
-  <td><a href="https://github.com/dataleading/jraft">JRaft</a></td>
+  <td><a href="https://github.com/dataleading/easyRaft">dataleading/easyRaft</a></td>
   <td><a href="https://github.com/dataleading/">Shanliang Shen</a></td>
   <td>Java</td>
   <td>Apache2.0</td>


### PR DESCRIPTION
Sorry, i just noticed there already a jraft repo name.  So, i renamed my repo to easyRaft.  Thanks!