### PR TITLE
add alt tags and meta description tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Raft is a consensus algorithm that is designed to be easy to understand.">
     <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css" integrity="sha384-dkTxiR4Mv8i0ubTj0fsgTCmhYmOtrc0o6rdrEO6hDZs9cAifak0Y2VVL2cecWHLQ" crossorigin="anonymous" >
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js" integrity="sha384-K+ctZQ+LL8q6tP7I94W+qzQsfRV2a+AfHIi9k8z8l9ggpc8X+Ytst4yBo/hH+8Fk" crossorigin="anonymous"></script>
     <script src="https://netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js" integrity="sha384-Zzs5x1/YUvlxpCu06c197tRCubLCMA7pCoHbZeoZuz/oEgYD6NVmvLzDSKYBoc3J" crossorigin="anonymous"></script>
@@ -112,7 +113,7 @@ blockquote p {
     <div class="container" style="margin-top: 50px">
       <h1>
         The Raft Consensus Algorithm
-        <img src="logo/annie-solo.png" style="width: 200px; height: 190px; margin: -40px auto;" />
+        <img src="logo/annie-solo.png" alt="" style="width: 200px; height: 190px; margin: -40px auto;" />
       </h1>
     </div>
 
@@ -297,7 +298,7 @@ These talks serve as good introductions to Raft:
     Talk on Raft at
     <a href="https://cs.illinois.edu/news/distinguished-lecture-series-dr-john-ousterhout">CS@Illinois Distinguished Lecture Series</a>
     by <a href="http://www.stanford.edu/~ouster/">John Ousterhout</a>, August 2016:
-    <img class="img-rounded pull-right" src="thumbnails/uiuc2016.jpg" />
+    <img class="img-rounded pull-right" src="thumbnails/uiuc2016.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Video</td>
@@ -317,7 +318,7 @@ These talks serve as good introductions to Raft:
     Talk on Raft and its TLA+ spec as part of
     <a href="https://github.com/tlaplus/DrTLAPlus">Dr. TLA+ Series</a>
     by <a href="https://research.microsoft.com/en-us/um/people/jinl/">Jin Li</a>, July 2016:
-    <img class="img-rounded pull-right" src="thumbnails/drtlaplus2016.jpg" />
+    <img class="img-rounded pull-right" src="thumbnails/drtlaplus2016.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Video</td>
@@ -336,7 +337,7 @@ These talks serve as good introductions to Raft:
     Talk on Raft at
     <a href="http://buildstuff.lt/">Build Stuff 2015</a>
     by <a href="https://twitter.com/ongardie">Diego Ongaro</a>, November 2015:
-    <img class="img-rounded pull-right" src="thumbnails/buildstufflt2015.jpg" />
+    <img class="img-rounded pull-right" src="thumbnails/buildstufflt2015.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Video</td>
@@ -363,7 +364,7 @@ These talks serve as good introductions to Raft:
     <a href="https://github.com/danburkert">Dan Burkert</a>, and
     <a href="https://twitter.com/posix4e">Alex Newman</a>,
     August 2015:
-    <img class="img-rounded pull-right" src="thumbnails/rust2015.jpg" />
+    <img class="img-rounded pull-right" src="thumbnails/rust2015.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Video</td>
@@ -384,7 +385,7 @@ These talks serve as good introductions to Raft:
     Talk on Raft at
     <a href="https://coreos.com/fest/">CoreOS Fest 2015</a>
     by <a href="https://twitter.com/ongardie">Diego Ongaro</a>, May 2015:
-    <img class="img-rounded pull-right" src="thumbnails/coreosfest2015.jpg" />
+    <img class="img-rounded pull-right" src="thumbnails/coreosfest2015.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Video</td>
@@ -404,7 +405,7 @@ These talks serve as good introductions to Raft:
     Talk on Raft at
     <a href="http://www.meetup.com/Sourcegraph-Hacker-Meetup/events/221199291/">Sourcegraph meetup</a>
     by <a href="https://twitter.com/ongardie">Diego Ongaro</a>, April 2015:
-    <img class="img-rounded pull-right" src="thumbnails/sourcegraph2015.jpg" />
+    <img class="img-rounded pull-right" src="thumbnails/sourcegraph2015.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Video</td>
@@ -424,7 +425,7 @@ These talks serve as good introductions to Raft:
   <li class="list-group-item clearfix">
     Talk on Raft at LinkedIn
     by <a href="https://twitter.com/ongardie">Diego Ongaro</a>, September 2014:
-    <img class="img-rounded pull-right" src="thumbnails/linkedin2014.jpg" />
+    <img class="img-rounded pull-right" src="thumbnails/linkedin2014.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Video</td>
@@ -447,7 +448,7 @@ These talks serve as good introductions to Raft:
     and
     <a href="http://devcycles.net/summer/sessions/index.php?session=3">/dev/summer 2014</a>
     by <a href="https://twitter.com/abailly">Arnaud Bailly</a>, July 2014:
-    <img class="img-rounded pull-right" src="thumbnails/usi2014.jpg" />
+    <img class="img-rounded pull-right" src="thumbnails/usi2014.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Video</td>
@@ -464,7 +465,7 @@ These talks serve as good introductions to Raft:
   <li class="list-group-item clearfix">
     Talk on Raft at <a href="https://www.usenix.org/conference/atc14/technical-sessions/presentation/ongaro">2014 USENIX Annual Technical Conference</a>
     by <a href="https://twitter.com/ongardie">Diego Ongaro</a>, June 2014:
-    <img class="img-rounded pull-right" src="thumbnails/atc2014.jpg" />
+    <img class="img-rounded pull-right" src="thumbnails/atc2014.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Video</td>
@@ -480,7 +481,7 @@ These talks serve as good introductions to Raft:
   <li class="list-group-item clearfix">
     Talk on Raft at <a href="http://craft-conf.com/2014/#speakers/DiegoOngaro">CraftConf 2014</a>
     by <a href="https://twitter.com/ongardie">Diego Ongaro</a>, April 2014:
-    <img class="img-rounded pull-right" src="thumbnails/craftconf2014.jpg" />
+    <img class="img-rounded pull-right" src="thumbnails/craftconf2014.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Video</td>
@@ -499,7 +500,7 @@ These talks serve as good introductions to Raft:
   <li class="list-group-item clearfix">
     Talk on Raft at <a href="http://rubyconf.org/program#patrick-van-stee">Rubyconf 2013</a>
     by <a href="https://twitter.com/vanstee">Patrick Van Stee</a>, November 2013:
-    <img class="img-rounded pull-right" src="thumbnails/rubyconf2013.jpg" />
+    <img class="img-rounded pull-right" src="thumbnails/rubyconf2013.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Video</td>
@@ -517,7 +518,7 @@ These talks serve as good introductions to Raft:
   <li class="list-group-item clearfix">
     Talk on Raft at <a href="http://ricon.io/west.html">RICON West 2013</a>
     by <a href="https://twitter.com/ongardie">Diego Ongaro</a>, October 2013:
-    <img class="img-rounded pull-right" src="thumbnails/riconwest2013.jpg" />
+    <img class="img-rounded pull-right" src="thumbnails/riconwest2013.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Video</td>
@@ -536,7 +537,7 @@ These talks serve as good introductions to Raft:
   <li class="list-group-item clearfix">
     Talk on Raft at <a href="https://thestrangeloop.com/sessions/raft-the-understandable-distributed-protocol">Strange Loop 2013</a>
     by <a href="https://twitter.com/benbjohnson">Ben Johnson</a>, September 2013:
-    <img class="img-rounded pull-right" src="thumbnails/strangeloop2013.jpg" />
+    <img class="img-rounded pull-right" src="thumbnails/strangeloop2013.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Video</td>
@@ -554,7 +555,7 @@ These talks serve as good introductions to Raft:
     at the <a href="http://www.meetup.com/Erlang-NYC/events/131394712/">Erlang NYC Meetup</a>
     by <a href="https://twitter.com/tsantero">Tom Santero</a> and
     <a href="https://twitter.com/andrew_j_stone">Andrew Stone</a>, August 2013:
-    <img class="img-rounded pull-right" src="thumbnails/erlangnyc2013.jpg" />
+    <img class="img-rounded pull-right" src="thumbnails/erlangnyc2013.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Video</td>
@@ -570,7 +571,7 @@ These talks serve as good introductions to Raft:
   <li class="list-group-item clearfix">
     Talk on Raft (venue unknown)
     by <a href="https://twitter.com/vanstee">Patrick Van Stee</a>, July 2013:
-    <img class="img-rounded pull-right" src="thumbnails/vanstee2013.jpg" />
+    <img class="img-rounded pull-right" src="thumbnails/vanstee2013.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Slides</td>
@@ -582,7 +583,7 @@ These talks serve as good introductions to Raft:
   <li class="list-group-item clearfix">
     Lecture for the <a href="https://ongardie.net/static/raft/userstudy/">Raft User Study</a>
     by <a href="http://www.stanford.edu/~ouster/">John Ousterhout</a>, March 2013:
-    <img class="img-thumbnail pull-right" src="thumbnails/userstudy2013.jpg" />
+    <img class="img-thumbnail pull-right" src="thumbnails/userstudy2013.jpg" alt="preview of the video" />
     <table class="table-condensed">
       <tr>
         <td>Video (screencast)</td>


### PR DESCRIPTION
The lack of alt tags was hurting the lighthouse score for both accessibility and seo, so that's an easy win. The reason for including `alt=""` for the icon is that if there is no alt tag, some screen readers will read the `src` attribute of the `img` element, which isn't very nice.

The description is also an easy win.