### PR TITLE
add simple-raft-rs

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -1848,6 +1848,27 @@
         }
     },
     {
+        "repoURL": "https://github.com/simple-raft-rs/raft-rs",
+        "name": "simple-raft-rs",
+        "authors": [
+            {
+                "name": "jessa0",
+                "github": "jessa0"
+            },
+            {
+                "name": "Signal Messenger"
+            }
+        ],
+        "language": "Rust",
+        "license": "AGPL-3.0-or-later",
+        "features": {
+            "basic": true,
+            "membershipChanges": false,
+            "logCompaction": false,
+            "persistence": false
+        }
+    },
+    {
         "repoURL": "https://github.com/srned/Prez",
         "name": "srned/Prez",
         "authors": [


### PR DESCRIPTION
I'd like to add [simple-raft-rs](https://github.com/simple-raft-rs/raft-rs) which is a simple Rust implementation forked from Signal Messenger's [Secure Value Recovery](https://signal.org/blog/secure-value-recovery/) project (mostly just moving it into a separate crate and adding documentation, examples, and a higher-level API).