### PR TITLE
add python3-raft

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -204,6 +204,27 @@
         }
     },
     {
+        "repoURL": "https://github.com/adsharma/raft",
+        "name": "python3-raft",
+        "authors": [
+            {
+                "name": "Arun Sharma",
+                "github": "adsharma"
+            },
+            {
+                "name": "Sean Reed"
+            }
+        ],
+        "language": "Python",
+        "license": "MIT",
+        "features": {
+            "basic": false,
+            "membershipChanges": true,
+            "logCompaction": false,
+            "persistence": true
+        }
+    },
+    {
         "repoURL": "https://github.com/akiradeveloper/lol",
         "name": "akiradeveloper/lol",
         "authors": [


### PR DESCRIPTION
This is a fork of simpleRaft with the following modifications:

* Uses python3 and static typing
* async/await based
* zeromq, zre and pyserde for msgpack based serialization
* bug fixes and tests

https://github.com/adsharma/zre_raft, a p2p encrypted chat app
uses this raft implementation for managing metadata.