### PR TITLE
Implementations: change Ratis to Apache Ratis

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -406,7 +406,7 @@
     },
     {
         "repoURL": "https://github.com/apache/ratis",
-        "name": "Ratis",
+        "name": "Apache Ratis",
         "authors": [
             {
                 "name": "Tsz-Wo (Nicholas) Sze",


### PR DESCRIPTION
Change implementation "Ratis" to "Apache Ratis" since it uses
"Apache Ratis" in its [README](https://github.com/apache/ratis) and [homepage](https://ratis.apache.org).