### PR TITLE
Fix wrong link

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@ it includes a simpler cluster membership change algorithm.
     Michael D. Ernst, and
     Thomas Anderson.
     <br />
-    <a href="http://verdi.uwplse.org/">Planning for Change in a Formal Verification of the Raft Consensus Protocol</a>.
+    <a href="https://dl.acm.org/doi/abs/10.1145/2854065.2854081">Planning for Change in a Formal Verification of the Raft Consensus Protocol</a>.
     <br />
     Certified Programs and Proofs (CPP), January 2016.
     </p>


### PR DESCRIPTION
The link to "Planning for Change in a Formal Verification of the Raft Consensus Protocol" is wrong, which duplicates the link below.