### PR TITLE
Add a course from the Technical University of Munich

### DIFF
--- a/index.html
+++ b/index.html
@@ -629,6 +629,14 @@ or an issue to update it.
 <!-- newest first -->
 <ul>
   <li>
+    <a href="https://www.tum.de/">Technical University of Munich</a>,
+    <a href="https://campus.tum.de/tumonline/ee/ui/ca2/app/desktop/#/slc.tm.cp/student/courses/950635146?lang=en">IN2259: Distributed Systems</a>,
+    <a href="https://dse.in.tum.de/bhatotia/">Pramod Bhatotia</a> and
+    <a href="https://martin.kleppmann.com/">Martin Kleppmann</a>.
+    Includes lecture on Raft. (Winter 2022/2023, ...)
+  </li>
+  
+  <li>
     <a href="https://illinois.edu">University of Illinois Urbana-Champaign</a>,
     <a href="https://courses.grainger.illinois.edu/cs425/">CS425: Distributed Systems</a>,
     <a href="http://indy.cs.illinois.edu">Indranil Gupta</a>,


### PR DESCRIPTION
Add a course from the Technical University of Munich to the list of courses teaching Raft.