### PR TITLE
Update repository URL for Atomix

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -497,15 +497,15 @@
         }
     },
     {
-        "repoURL": "https://github.com/atomix/atomix",
-        "name": "atomix",
+        "repoURL": "https://github.com/atomix/atomix-archive",
+        "name": "atomix (archived)",
         "authors": [
             {
                 "name": "Jordan Halterman",
                 "twitter": "definekuujo"
             }
         ],
-        "language": "Go",
+        "language": "Java",
         "license": "Apache-2.0",
         "features": {
             "basic": true,

--- a/implementations.json
+++ b/implementations.json
@@ -505,7 +505,7 @@
                 "twitter": "definekuujo"
             }
         ],
-        "language": "Java",
+        "language": "Go",
         "license": "Apache-2.0",
         "features": {
             "basic": true,


### PR DESCRIPTION
[Atomix](https://github.com/atomix/atomix) is currently categorised as Java but it's actually written in Go.