### PR TITLE
Correct license of canonical/raft

### DIFF
--- a/implementations.json
+++ b/implementations.json
@@ -680,7 +680,7 @@
             }
         ],
         "language": "C",
-        "license": "Apache-2.0",
+        "license": "LGPL-3.0 Linking Exception",
         "features": {
             "basic": true,
             "membershipChanges": true,


### PR DESCRIPTION
> This raft C library is released under a slightly modified version of LGPLv3, that includes a copyright exception letting users to statically link the library code in their project and release the final work under their own terms. See the full [license](https://github.com/canonical/raft/blob/LICENSE) text.

License of [canonical/raft](https://github.com/canonical/raft) should be [LGPL-3.0 Linking Exception](https://spdx.org/licenses/LGPL-3.0-linking-exception.html)