### PR TITLE
Add The University of Hong Kong to course list

### DIFF
--- a/index.html
+++ b/index.html
@@ -638,6 +638,13 @@ or an issue to update it.
 <!-- newest first -->
 <ul>
   <li>
+    <a href="https://www.hku.hk/">The University of Hong Kong</a>,
+    <a href="https://www.cs.hku.hk/index.php/programmes/course-offered?infile=2019/comp3358.html">COMP3358: Distributed and Parallel Computing</a>,
+    <a href="https://www.cs.hku.hk/people/academic-staff/heming">Heming Cui</a>.
+    Includes lecture on Raft. (Spring 2024)
+  </li>
+
+  <li>
     <a href="https://www.virginia.edu/">University of Virginia</a>,
     <a href="https://changlousys.github.io/CS4740/spring24/about/">CS4740: Cloud Computing</a>,
     <a href="https://changlousys.github.io/">Chang Lou</a>.


### PR DESCRIPTION
Add a course from The University of Hong Kong to the list of courses teaching Raft.
