### PR TITLE
fix some broken links

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,7 +267,7 @@ specification is <a href="https://github.com/ongardie/raft.tla">here</a>.
     Michael D. Ernst, and
     Thomas Anderson.
     <br />
-    <a href="http://verdi.uwplse.org/">Verdi: A Framework for Implementing and Verifying Distributed Systems</a>.
+    <a href="https://dl.acm.org/doi/pdf/10.1145/2737924.2737958">Verdi: A Framework for Implementing and Verifying Distributed Systems</a>.
     <br />
     Programming Language Design and Implementation (PLDI), June 2015.
     </p>
@@ -289,7 +289,7 @@ specification is <a href="https://github.com/ongardie/raft.tla">here</a>.
     Anil Madhavapeddy, and
     Jon Crowcroft.
     <br />
-    <a href="https://www.cl.cam.ac.uk/~ms705/pub/papers/2015-osr-raft.pdf">Raft Refloated: Do We Have Consensus?</a>.
+    <a href="https://api.repository.cam.ac.uk/server/api/core/bitstreams/c9bcee5b-a1cb-4147-9281-1a05632f5aa3/content">Raft Refloated: Do We Have Consensus?</a>.
     <br />
     SIGOPS Operating Systems Review, January 2015.
     </p>


### PR DESCRIPTION
Fixed some broken links about the more Raft-related papers. In particular:
- Verdi: A Framework for Implementing and Verifying Distributed Systems
- Raft Refloated: Do We Have Consensus?

For the first one, I've replaced the site with the original paper, maybe it could be used the wayback machine [shapshot](https://web.archive.org/web/20230130023430/https://verdi.uwplse.org/) if prefered.